### PR TITLE
[FIX] switch to using docker-compose internal dns

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,7 +8,7 @@ services:
       - POSTGRES_PASSWORD=airflow
       - POSTGRES_DB=airflow
     ports:
-      - 5439:5432
+      - 5432:5432
     volumes:
       - postgres:/var/lib/postgresql/data
 
@@ -21,7 +21,7 @@ services:
       AIRFLOW__CORE__LOAD_EXAMPLES: "False"
       AIRFLOW__CORE__EXECUTOR: LocalExecutor
       AIRFLOW__CORE__FERNET_KEY: ""
-      AIRFLOW__CORE__SQL_ALCHEMY_CONN: postgresql+psycopg2://airflow:airflow@host.docker.internal:5439/airflow
+      AIRFLOW__CORE__SQL_ALCHEMY_CONN: postgresql+psycopg2://airflow:airflow@postgres:5432/airflow
     command: bash -c "airflow db init && airflow users create --firstname admin --lastname admin --email admin --password admin --username admin --role Admin"
 
   webserver:


### PR DESCRIPTION
This resolves #12 

The docker-compose syntax on Mac OS for connecting a container to a process running on your local port outside of the docker-compose network is to use the keyword `host.docker.internal` as the host of your connection string. This doesn't work on other OS, so we should switch to using docker-compose's internal DNS to be OS-agnostic. 

Also changes the port the Airflow DB was exposed on - it was previously 5439 so as to allow for running another Postgres database on 5432, but we will let users change this for their actual use case. 